### PR TITLE
Add Essentia-based audio pie chart demo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app",
       "version": "0.0.0",
       "dependencies": {
+        "essentia.js": "^0.1.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1641,6 +1642,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/essentia.js": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/essentia.js/-/essentia.js-0.1.3.tgz",
+      "integrity": "sha512-vVEPgeVMEBLRXbM5o5H5Rgu53EPHu25vyFKYg+flWLzI/nEoegJQez9FKRv8GR/KxIBwm+fXDEFL+MkQeoHaLw==",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "node-wav": "0.0.2"
+      }
+    },
     "node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
@@ -1992,6 +2002,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-wav": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/node-wav/-/node-wav-0.0.2.tgz",
+      "integrity": "sha512-M6Rm/bbG6De/gKGxOpeOobx/dnGuP0dz40adqx38boqHhlWssBJZgLCPBNtb9NkrmnKYiV04xELq+R6PFOnoLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.4.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "essentia.js": "^0.1.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -3,13 +3,11 @@
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
 }
-
 
 #audio-pie {
   position: relative;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,6 @@
 import AudioPie from '@/com/AudioPie'
-
 import './App.css'
 
-
-function App() {
-  return <>
-    <AudioPie />
-  </>
+export default function App() {
+  return <AudioPie />
 }
-
-export default App

--- a/src/com/AudioPie.jsx
+++ b/src/com/AudioPie.jsx
@@ -1,14 +1,65 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import PieSlice from './PieSlice'
+import EssentiaWASM from 'essentia.js/dist/essentia-wasm.es.js'
+import Essentia from 'essentia.js/dist/essentia.js-core.es.js'
 
+const NOTES = ['A', 'A#', 'B', 'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#']
 
 export default function AudioPie() {
-  return <>
-    <svg width="500" height="500" viewBox="0 0 100 100"
-      id="audio-pie"
-    >
-      <circle cx="50" cy="50" r="40" stroke="black" strokeWidth="3" fill="none" />
-      <path d="M50,10 A40,40 0 1,1 50,90 A40,40 0 1,1 50,10" fill="none" stroke="blue" strokeWidth="3" />
-      <text x="50" y="55" fontSize="12" textAnchor="middle" fill="black">Audio</text>
+  const [active, setActive] = useState(null)
+
+  useEffect(() => {
+    const audioCtx = new (window.AudioContext || window.webkitAudioContext)()
+    const essentia = new Essentia(EssentiaWASM)
+    let source
+    let processor
+
+    navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
+      source = audioCtx.createMediaStreamSource(stream)
+      processor = audioCtx.createScriptProcessor(4096, 1, 1)
+      source.connect(processor)
+      processor.connect(audioCtx.destination)
+
+      processor.onaudioprocess = e => {
+        const frame = e.inputBuffer.getChannelData(0)
+        const windowed = essentia.Windowing(frame).frame
+        const spectrum = essentia.Spectrum(windowed).spectrum
+        const peaks = essentia.SpectralPeaks(spectrum, 0.0001, audioCtx.sampleRate / 2, 60, 40, 'frequency', audioCtx.sampleRate)
+        const hpcp = essentia.HPCP(peaks.frequencies, peaks.magnitudes, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, audioCtx.sampleRate).hpcp
+        let maxIndex = 0
+        for (let i = 1; i < hpcp.length; i++) {
+          if (hpcp[i] > hpcp[maxIndex]) maxIndex = i
+        }
+        setActive(maxIndex)
+      }
+    })
+
+    return () => {
+      processor && processor.disconnect()
+      source && source.disconnect()
+      audioCtx && audioCtx.close()
+    }
+  }, [])
+
+  const radius = 40
+  const cx = 50
+  const cy = 50
+  const sliceAngle = 360 / NOTES.length
+
+  return (
+    <svg width="500" height="500" viewBox="0 0 100 100" id="audio-pie">
+      {NOTES.map((n, i) => (
+        <PieSlice
+          key={n}
+          startAngle={i * sliceAngle}
+          endAngle={(i + 1) * sliceAngle}
+          radius={radius}
+          cx={cx}
+          cy={cy}
+          label={n}
+          fill={active === i ? '#ff8080' : '#ccc'}
+        />
+      ))}
     </svg>
-  </>
+  )
 }

--- a/src/com/PieSlice.jsx
+++ b/src/com/PieSlice.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+export default function PieSlice({ startAngle, endAngle, radius, cx, cy, fill, label }) {
+  const rad = Math.PI / 180
+  const x1 = cx + radius * Math.cos(startAngle * rad)
+  const y1 = cy + radius * Math.sin(startAngle * rad)
+  const x2 = cx + radius * Math.cos(endAngle * rad)
+  const y2 = cy + radius * Math.sin(endAngle * rad)
+  const largeArc = endAngle - startAngle > 180 ? 1 : 0
+  const pathData = `M ${cx} ${cy} L ${x1} ${y1} A ${radius} ${radius} 0 ${largeArc} 1 ${x2} ${y2} Z`
+  const midAngle = (startAngle + endAngle) / 2
+  const tx = cx + (radius * 0.7) * Math.cos(midAngle * rad)
+  const ty = cy + (radius * 0.7) * Math.sin(midAngle * rad)
+  return (
+    <g>
+      <path d={pathData} fill={fill} stroke="black" strokeWidth="0.5" />
+      <text x={tx} y={ty} fontSize="3" textAnchor="middle" dominantBaseline="middle" pointerEvents="none">{label}</text>
+    </g>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,17 +2,14 @@
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-
 
 body {
   position: absolute;


### PR DESCRIPTION
## Summary
- install `essentia.js`
- add `PieSlice` and `AudioPie` React components
- build real-time note detection with Essentia
- highlight the detected note on an SVG pie chart

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fbc143e548327841428ec62f8050a