### PR TITLE
Improve chart styling

### DIFF
--- a/src/chartConfig.js
+++ b/src/chartConfig.js
@@ -27,12 +27,16 @@ const CHART_CONFIG = {
             {
                 // hpcp intensity ring
                 data: Array(12).fill(1),
-                backgroundColor: KEYS.map(k => `hsl(${PITCH_CLASS_COLORS[k]}, 0%, 25%)`),
+                backgroundColor: KEYS.map(k => `hsl(${PITCH_CLASS_COLORS[k]}, 100%, 50%)`),
+                borderColor: 'rgba(255,255,255,0.2)',
+                borderWidth: 1,
                 borderAlign: 'inner'
             },
             ...OCTAVES.map(() => ({
                 data: Array(12).fill(1),
                 backgroundColor: Array(12).fill('rgba(0,0,0,0.1)'),
+                borderColor: 'rgba(255,255,255,0.2)',
+                borderWidth: 1,
                 borderAlign: 'inner'
             }))
         ]
@@ -59,19 +63,7 @@ const CHART_CONFIG = {
         },
         plugins: {
             datalabels: {
-                color: "#fff",
-                formatter: function(value, context) {
-                    return context.chart.data.labels[context.dataIndex];
-                },
-                anchor: 'center',
-                align: 'end',
-                offset: function(context) {
-                    context.chart.options.plugins.datalabels.offset = 0.04*context.chart.width;
-                    context.chart.update();
-                },
-                font: {
-                    size: 16
-                }
+                display: false
             }
         }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,7 @@ function onRecordEssentiaFeatureExtractor(event) {
 
     // update hpcp intensity ring (dataset 0)
     chromaChart.data.datasets[0].backgroundColor = KEYS.map((k, i) =>
-      `hsl(${PITCH_CLASS_COLORS[k]}, ${scaledHPCP[i]}%, ${25 + scaledHPCP[i] / 3}%)`
+      `hsl(${PITCH_CLASS_COLORS[k]}, 100%, ${50 + scaledHPCP[i] / 2}%)`
     );
 
     // detect pitch and octave using PitchYin
@@ -155,7 +155,7 @@ function onRecordEssentiaFeatureExtractor(event) {
 
     chromaChart.update();
   } else {
-    chromaChart.data.datasets[0].backgroundColor = KEYS.map(k => `hsl(${PITCH_CLASS_COLORS[k]}, 0%, 25%)`);
+    chromaChart.data.datasets[0].backgroundColor = KEYS.map(k => `hsl(${PITCH_CLASS_COLORS[k]}, 100%, 50%)`);
     OCTAVES.forEach((oct, idx) => {
       chromaChart.data.datasets[idx + 1].backgroundColor = Array(12).fill('rgba(0,0,0,0.1)');
     });


### PR DESCRIPTION
## Summary
- brighten chart colors and use subtle borders
- disable datalabels

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687fdd9f343083279e51b9036c03bdc7